### PR TITLE
remove redundant PermissionsResultAction object in mPendingActions list, fixed a wrong callback issue

### DIFF
--- a/library/src/main/java/com/anthonycr/grant/PermissionsManager.java
+++ b/library/src/main/java/com/anthonycr/grant/PermissionsManager.java
@@ -57,6 +57,16 @@ public final class PermissionsManager {
         mPendingActions.add(new WeakReference<>(action));
     }
 
+    private synchronized void removePendingAction(PermissionsResultAction action) {
+        for (Iterator<WeakReference<PermissionsResultAction>> iterator = mPendingActions.iterator();
+             iterator.hasNext(); ) {
+            WeakReference<PermissionsResultAction> weakRef = iterator.next();
+            if (weakRef.get() == action) {
+                iterator.remove();
+            }
+        }
+    }
+
     /**
      * This static method can be used to check whether or not you have a specific permission.
      * It is basically a less verbose method of using {@link ActivityCompat#checkSelfPermission(Context, String)}
@@ -172,7 +182,10 @@ public final class PermissionsManager {
             doPermissionWorkBeforeAndroidM(activity, permissions, action);
         } else {
             List<String> permList = getPermissionsListToRequest(activity, permissions, action);
-            if (!permList.isEmpty()) {
+            if (permList.isEmpty()) {
+                //if there is no permission to request, there is no reason to keep the action int the list
+                removePendingAction(action);
+            } else {
                 String[] permsToRequest = permList.toArray(new String[permList.size()]);
                 mPendingRequests.addAll(permList);
                 ActivityCompat.requestPermissions(activity, permsToRequest, 1);
@@ -206,7 +219,10 @@ public final class PermissionsManager {
             doPermissionWorkBeforeAndroidM(activity, permissions, action);
         } else {
             List<String> permList = getPermissionsListToRequest(activity, permissions, action);
-            if (!permList.isEmpty()) {
+            if (permList.isEmpty()) {
+                //if there is no permission to request, there is no reason to keep the action int the list
+                removePendingAction(action);
+            } else {
                 String[] permsToRequest = permList.toArray(new String[permList.size()]);
                 mPendingRequests.addAll(permList);
                 fragment.requestPermissions(permsToRequest, 1);

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
 
     <application
         android:allowBackup="false"

--- a/sample/src/main/java/com/anthonycr/sample/ContactsUtils.java
+++ b/sample/src/main/java/com/anthonycr/sample/ContactsUtils.java
@@ -1,0 +1,55 @@
+package com.anthonycr.sample;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.provider.ContactsContract;
+import android.util.Log;
+
+public class ContactsUtils {
+    private static final String DEBUG_TAG = "PermissionTest";
+
+    public static void readPhoneContacts(Context context) {
+        ContentResolver contentResolver = context.getContentResolver();
+        Cursor cursor = contentResolver.query(ContactsContract.Contacts.CONTENT_URI, null, null, null, null);
+        if (null != cursor && cursor.getCount() > 0) {
+            while (cursor.moveToNext()) {
+                String id = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts._ID));
+                String contactName = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME));
+                Log.e(DEBUG_TAG, "================= " + contactName + " ==========");
+                if (Integer.parseInt(cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts.HAS_PHONE_NUMBER))) > 0) {
+                    Cursor pCursor = contentResolver.query(ContactsContract.CommonDataKinds.Phone.CONTENT_URI, null,
+                            ContactsContract.CommonDataKinds.Phone.CONTACT_ID + " = ?",
+                            new String[]{id}, null);
+                    if (null != pCursor) {
+                        while (pCursor.moveToNext()) {
+                            int phoneType = pCursor.getInt(pCursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.TYPE));
+                            String phoneNo = pCursor.getString(pCursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER));
+                            switch (phoneType) {
+                                case ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE:
+                                    Log.i(contactName + ": TYPE_MOBILE", " " + phoneNo);
+                                    break;
+                                case ContactsContract.CommonDataKinds.Phone.TYPE_HOME:
+                                    Log.i(contactName + ": TYPE_HOME", " " + phoneNo);
+                                    break;
+                                case ContactsContract.CommonDataKinds.Phone.TYPE_WORK:
+                                    Log.i(contactName + ": TYPE_WORK", " " + phoneNo);
+                                    break;
+                                case ContactsContract.CommonDataKinds.Phone.TYPE_WORK_MOBILE:
+                                    Log.i(contactName + ": TYPE_WORK_MOBILE", " " + phoneNo);
+                                    break;
+                                case ContactsContract.CommonDataKinds.Phone.TYPE_OTHER:
+                                    Log.i(contactName + ": TYPE_OTHER", " " + phoneNo);
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                        pCursor.close();
+                    }
+                }
+            }
+            cursor.close();
+        }
+    }
+}

--- a/sample/src/main/java/com/anthonycr/sample/MainActivity.java
+++ b/sample/src/main/java/com/anthonycr/sample/MainActivity.java
@@ -113,6 +113,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        Log.i(TAG, "Activity-onRequestPermissionsResult() PermissionsManager.notifyPermissionsChange()");
         PermissionsManager.getInstance().notifyPermissionsChange(permissions, grantResults);
     }
 
@@ -125,11 +126,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
                             @Override
                             public void onGranted() {
+                                Log.i(TAG, "onGranted: Write Storage");
                                 writeToStorage();
                             }
 
                             @Override
                             public void onDenied(String permission) {
+                                Log.i(TAG, "onDenied: Write Storage");
                                 String message = String.format(Locale.getDefault(), getString(R.string.message_denied), permission);
                                 Toast.makeText(MainActivity.this, message, Toast.LENGTH_SHORT).show();
                             }
@@ -142,11 +145,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
                             @Override
                             public void onGranted() {
+                                Log.i(TAG, "onGranted: Read Storage");
                                 readFromStorage();
                             }
 
                             @Override
                             public void onDenied(String permission) {
+                                Log.i(TAG, "onDenied: Read Storage");
                                 String message = String.format(Locale.getDefault(), getString(R.string.message_denied), permission);
                                 Toast.makeText(MainActivity.this, message, Toast.LENGTH_SHORT).show();
                             }
@@ -159,11 +164,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
                             @Override
                             public void onGranted() {
+                                Log.i(TAG, "onGranted: Read Contacts");
                                 ContactsUtils.readPhoneContacts(MainActivity.this);
                             }
 
                             @Override
                             public void onDenied(String permission) {
+                                Log.i(TAG, "onDenied: Read Contacts");
                                 String message = String.format(Locale.getDefault(), getString(R.string.message_denied), permission);
                                 Toast.makeText(MainActivity.this, message, Toast.LENGTH_SHORT).show();
                             }
@@ -179,6 +186,18 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             closeable.close();
         } catch (IOException ignored) {}
     }
+
+
+    // I found an issue, which can be seen from the logs, here is the steps:
+    // 1. click read contacts button, popup the dialog, select "Allow", the Log "onGranted: Read Contacts" shown.
+    // 2. click the read contacts button again, do the read contacts work directly, the Log "onGranted: Read Contacts" shown.
+    // 3. click the read storage button, popup the dialog, select "Deny".
+    // Bug: Both the Log "onDenied: Read Contacts" and "onDenied: Read Storage" shown.
+
+    // If we repeat the step 2 for many times, we will get many "onDenied: Read Contacts" logs on step 3.
+
+    // Reason: if we request a permission we already have, the onRequestPermissionsResult() is not invoked
+    // so the PermissionsManager.getInstance().notifyPermissionsChange(permissions, grantResults); is not invoked too.
 }
 
 

--- a/sample/src/main/java/com/anthonycr/sample/MainActivity.java
+++ b/sample/src/main/java/com/anthonycr/sample/MainActivity.java
@@ -53,11 +53,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         Button writeStorage = (Button) findViewById(R.id.button_write_storage);
         Button readStorage = (Button) findViewById(R.id.button_read_storage);
+        Button readContacts = (Button) findViewById(R.id.button_read_contacts);
 
         this.textView = (TextView) findViewById(R.id.text);
 
         writeStorage.setOnClickListener(this);
         readStorage.setOnClickListener(this);
+        readContacts.setOnClickListener(this);
     }
 
     /**
@@ -141,6 +143,23 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                             @Override
                             public void onGranted() {
                                 readFromStorage();
+                            }
+
+                            @Override
+                            public void onDenied(String permission) {
+                                String message = String.format(Locale.getDefault(), getString(R.string.message_denied), permission);
+                                Toast.makeText(MainActivity.this, message, Toast.LENGTH_SHORT).show();
+                            }
+                        }
+                );
+                break;
+            case R.id.button_read_contacts:
+                PermissionsManager.getInstance().requestPermissionsIfNecessaryForResult(this,
+                        new String[]{Manifest.permission.READ_CONTACTS}, new PermissionsResultAction() {
+
+                            @Override
+                            public void onGranted() {
+                                ContactsUtils.readPhoneContacts(MainActivity.this);
                             }
 
                             @Override

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -33,4 +33,11 @@
         android:padding="10dp"
         android:text="@string/button_title_read_storage"/>
 
+    <Button
+        android:id="@+id/button_read_contacts"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="10dp"
+        android:text="@string/button_title_read_phone_contacts"/>
+
 </LinearLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="message_denied">Permission \"%1$s\" has been denied.</string>
     <string name="button_title_write_storage">Write to Storage</string>
     <string name="button_title_read_storage">Read from Storage</string>
+    <string name="button_title_read_phone_contacts">Read Phone Contacts</string>
     <string name="text_write">Wrote: \"%1$s\"</string>
     <string name="text_read">Read: \"%1$s\"</string>
     <string name="text_failure_write">Unable to write to storage.</string>


### PR DESCRIPTION
Hi, anthonycr
I'm using your lib for the runtime permissions request. Thanks for you great work!
I've found a issue when a permission is already granted, request another permission, the wrong callback method will be invoked.

I added some codes in your sample to reproduce this issue and then I add my solution in your lib to fix it.
Now it works well.
I'd like you take a look and merge it. Thanks!
