### PR TITLE
Remove final modifier for PermissionsManager.

### DIFF
--- a/library/src/main/java/com/anthonycr/grant/PermissionsManager.java
+++ b/library/src/main/java/com/anthonycr/grant/PermissionsManager.java
@@ -23,7 +23,7 @@ import java.util.Set;
 /**
  * A class to help you manage your permissions simply.
  */
-public final class PermissionsManager {
+public class PermissionsManager {
 
     private static final String TAG = PermissionsManager.class.getSimpleName();
     private static final PermissionsManager INSTANCE = new PermissionsManager();


### PR DESCRIPTION
Why PermissionsManager class use final? 
In my point of view, I think no class will inherit the Manager class. If they inherit it, the developer have the duty to make sure his/her inherited class can work in right way.

Another reason is that:
We can not test it(Mock it).
