### PR TITLE
Support SYSTEM_ALERT_WINDOW through Settings.canDrawOverlays()

### DIFF
--- a/library/src/main/java/com/anthonycr/grant/PermissionsManager.java
+++ b/library/src/main/java/com/anthonycr/grant/PermissionsManager.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
@@ -353,6 +354,16 @@ public class PermissionsManager {
             if (!mPermissions.contains(perm)) {
                 if (action != null) {
                     action.onResult(perm, Permissions.NOT_FOUND);
+                }
+            } else if (Manifest.permission.SYSTEM_ALERT_WINDOW.equals(perm)) {
+                if (Settings.canDrawOverlays(activity)) {
+                    if (action != null) {
+                        action.onResult(perm, Permissions.GRANTED);
+                    }
+                } else {
+                    if (!mPendingRequests.contains(perm)) {
+                        permList.add(perm);
+                    }
                 }
             } else if (ActivityCompat.checkSelfPermission(activity, perm) != PackageManager.PERMISSION_GRANTED) {
                 if (!mPendingRequests.contains(perm)) {

--- a/library/src/main/java/com/anthonycr/grant/PermissionsManager.java
+++ b/library/src/main/java/com/anthonycr/grant/PermissionsManager.java
@@ -1,6 +1,7 @@
 package com.anthonycr.grant;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageInfo;
@@ -342,6 +343,7 @@ public class PermissionsManager {
      *                    permission check
      * @return a list of permissions names that are not granted yet
      */
+    @TargetApi(Build.VERSION_CODES.M)
     @NonNull
     private List<String> getPermissionsListToRequest(@NonNull Activity activity,
                                                      @NonNull String[] permissions,


### PR DESCRIPTION
getPermissionsListToRequest() uses ActivityCompat.checkSelfPermission() to check if the permission is granted.

SYSTEM_ALERT_WINDOW is a 'special' dangerous permission, requiring the grant process through a special Settings.ACTION_MANAGE_OVERLAY_PERMISSION intent. Apparently, even if granting the access through the new Activity, ActivityCompat.checkSelfPermission() will return PERMISSION_DENIED.

I propose this tiny fix with uses Settings.canDrawOverlays() for SYSTEM_ALERT_WINDOW instead. Before requestAllManifestPermissionsIfNecessary() always called onDenied() if you worked with the special permission despite granting all other permissions access!
